### PR TITLE
added support for TWILIO_* env vars

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -4,10 +4,16 @@ import { success, error } from './util';
 
 export async function cli(args) {
     let { accountSid, authToken } = parseArgs();
+    const { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } = process.env;
 
     if (!accountSid || !authToken) {
-        console.error('usage: flex-channel-janitor --account-sid $account_sid --auth-token $token')
-        return;
+        if (TWILIO_ACCOUNT_SID && TWILIO_AUTH_TOKEN) {
+            accountSid = TWILIO_ACCOUNT_SID;
+            authToken = TWILIO_AUTH_TOKEN;
+        } else {
+            console.error('usage: flex-channel-janitor --account-sid $account_sid --auth-token $token')
+            return;
+        }
     }
 
     try {


### PR DESCRIPTION
Hi there! I've added support for TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN env vars to the cli, so we don't have to specify them as args in case they're already available as environment variables.